### PR TITLE
feat: upgrade zego_zim to ^2.28.0

### DIFF
--- a/lib/src/services/core/message_reaction.dart
+++ b/lib/src/services/core/message_reaction.dart
@@ -60,7 +60,8 @@ extension ZIMKitCoreMessageReaction on ZIMKitCore {
   }
 
   void onMessageReactionsChanged(
-      ZIM zim, List<ZIMMessageReaction> reactions) async {
+      ZIM zim, ZIMMessageReactionsChangedEventResult result) async {
+    final reactions = result.reactions;
     ZIMKitLogger.logInfo('onMessageReactionsChanged: ${reactions.length}');
     if (reactions.isEmpty) return;
 

--- a/lib/src/services/core/message_reaction.dart
+++ b/lib/src/services/core/message_reaction.dart
@@ -13,7 +13,7 @@ extension ZIMKitCoreMessageReaction on ZIMKitCore {
 
     await ZIM
         .getInstance()!
-        .addMessageReaction(reactionType, message.zim)
+        .addMessageReaction(reactionType: reactionType, message: message.zim)
         .then((result) {
       ZIMKitLogger.logInfo(
           'addMessageReaction: success, $reactionType, messageID:${message.info.messageID}');
@@ -42,7 +42,7 @@ extension ZIMKitCoreMessageReaction on ZIMKitCore {
 
     await ZIM
         .getInstance()!
-        .deleteMessageReaction(reactionType, message.zim)
+        .deleteMessageReaction(reactionType: reactionType, message: message.zim)
         .then((result) {
       ZIMKitLogger.logInfo(
           'deleteMessageReaction: success, $reactionType, messageID:${message.info.messageID}');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zego_zimkit
 description: A low-code plugin that provides a wrapper for IM widgets. Aims to simplify the development process by offering a user-friendly solution into applications.
-version: 1.19.9
+version: 1.20.0
 homepage: https://www.zegocloud.com/
 screenshots:
   - description: "A full-featured chat kit that enables you to easily build one-on-one or group chat into your app in minutes."
@@ -15,8 +15,8 @@ dependencies:
     sdk: flutter
 
   zego_plugin_adapter: ^2.14.0
-  zego_uikit_signaling_plugin: ^2.8.19
-  zego_zim: ^2.21.1+1
+  zego_uikit_signaling_plugin: ^2.8.20
+  zego_zim: ^2.28.0
   zego_zim_audio: ^1.0.0+1
   zego_zpns: ^2.8.0
 


### PR DESCRIPTION
## Summary

- Upgrade zego_zim dependency from ^2.21.1+1 to ^2.28.0
- Upgrade zego_uikit_signaling_plugin dependency to ^2.8.20
- Fix API compatibility for zego_zim 2.28.0

## Related
- FEAT-20260427-001: Flutter UIKits ZIM/ZPNS version upgrade

## Verification
- flutter analyze: 0 errors